### PR TITLE
require node 16 as adapter-code 3.x.x fails with node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "https://github.com/iobroker-community-adapters/ioBroker.logparser"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3"
   },


### PR DESCRIPTION
adapter core 3.x.x. fails to install on node 14 systems.
So require node 16 or newer.

Please increase minor version number at next release