### PR TITLE
Update jsonConfig.json - fix typo

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -586,7 +586,7 @@
 					"sm": 12,
 					"md": 6,
 					"lg": 3,
-					"xl": 43
+					"xl": 3
 				},
 				"cssMessage": {
 					"type": "checkbox",


### PR DESCRIPTION
Fix
❗ [E509] "xl" value (43) for checkbox greater then value for smaller displays

❗ [E511] invalid size attributes "xl":"43" for checkbox at admin/jsonConfig.json/items/_visualization/cssFrom. Value must be 1 to 12.