### PR TITLE
Update io-package.json - fix admin and js-controller dependencies

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -141,12 +141,12 @@
 		},
 		"dependencies": [
 			{
-				"js-controller": ">=5.0.0"
+				"js-controller": ">=5.0.19"
 			}
 		],
 		"globalDependencies": [
 			{
-				"admin": ">=6.0.0"
+				"admin": ">=6.17.14"
 			}
 		],
 		"logTransporter": true,


### PR DESCRIPTION
fixes 

[E157] admin 6.0.0 listed as dependency but 6.17.14 is required as minimum, 7.4.10 is recommended. Please update globalDependency at [io-package.json](https://github.com/iobroker-community-adapters/ioBroker.logparser/blob/master/io-package.json).

[E157] js-controller 5.0.0 listed as dependency but 5.0.19 is required as minimum. Please update dependency at [io-package.json](https://github.com/iobroker-community-adapters/ioBroker.logparser/blob/master/io-package.json).